### PR TITLE
feat: add includeSources and excludeSources filter settings

### DIFF
--- a/package.json
+++ b/package.json
@@ -128,6 +128,15 @@
             "default": [],
             "description": "Hide tasks from specific sources (e.g. [\"npm\", \"gulp\"])",
             "scope": "resource"
+          },
+          "vscodeTasksSidebar.includeSources": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "default": [],
+            "description": "Only show tasks from these sources. When set, all other sources are hidden. Takes priority over excludeSources.",
+            "scope": "resource"
           }
         }
       }

--- a/src/vscode-tasks-sidebar/settings.ts
+++ b/src/vscode-tasks-sidebar/settings.ts
@@ -11,3 +11,9 @@ export function getExcludedSources(): string[] {
     .getConfiguration()
     .get<string[]>('vscodeTasksSidebar.excludeSources', []);
 }
+
+export function getIncludeSources(): string[] {
+  return vscode.workspace
+    .getConfiguration()
+    .get<string[]>('vscodeTasksSidebar.includeSources', []);
+}

--- a/src/vscode-tasks-sidebar/vscodeTasksProvider.ts
+++ b/src/vscode-tasks-sidebar/vscodeTasksProvider.ts
@@ -1,5 +1,5 @@
 import * as vscode from 'vscode';
-import { isResultGrouped, getExcludedSources } from './settings';
+import { isResultGrouped, getExcludedSources, getIncludeSources } from './settings';
 import { VscodeGroup } from './vscodeGroup';
 import { VscodeTask } from './vscodeTask';
 
@@ -28,12 +28,14 @@ export class VscodeTasksProvider
       }
 
       const excludedSources = getExcludedSources().map((s) => s.toLowerCase());
+      const includeSources = getIncludeSources().map((s) => s.toLowerCase());
       const cacheTasks: VscodeTask[] = [];
       for (const task of tasks) {
-        if (
-          excludedSources.length > 0 &&
-          excludedSources.includes(task.source.toLowerCase())
-        ) {
+        const source = task.source.toLowerCase();
+        if (includeSources.length > 0 && !includeSources.includes(source)) {
+          continue;
+        }
+        if (excludedSources.length > 0 && excludedSources.includes(source)) {
           continue;
         }
         cacheTasks.push(new VscodeTask(task));


### PR DESCRIPTION
## Summary

Adds two new settings to filter which tasks appear in the sidebar:

- `vscodeTasksSidebar.excludeSources` — blacklist: hide tasks from specific sources
- `vscodeTasksSidebar.includeSources` — whitelist: only show tasks from listed sources

Both settings are case-insensitive. When `includeSources` is set, a task must be in the whitelist to appear. `excludeSources` is then applied as an additional filter.

### Examples

```jsonc
// Blacklist: hide auto-detected tasks from specific extensions
"vscodeTasksSidebar.excludeSources": ["npm", "gulp"]

// Whitelist: only show workspace-defined tasks
"vscodeTasksSidebar.includeSources": ["Workspace"]
```

## Problem

Some VS Code extensions unconditionally register tasks with no option to disable them. These auto-detected tasks often have long, verbose names that push the source badge out of view, making the sidebar harder to scan. Mixed in with user-defined workspace tasks, they create visual clutter and can be confusing — especially when their names don't clearly indicate what they do.

These settings give users control over which task sources appear in the sidebar, keeping it clean and focused on relevant tasks.

Related: #6