### PR TITLE
Add setting to filter tasks by origin (all, auto-detected, or workspace only)

### DIFF
--- a/package.json
+++ b/package.json
@@ -132,6 +132,18 @@
             "default": "",
             "description": "VSCode Tasks in Sidebar: hide tasks from specific sources (comma-separated)",
             "scope": "resource"
+          },
+          "vscodeTasksSidebar.taskSource": {
+            "type": "string",
+            "default": "all",
+            "enum": ["all", "autoDetected", "workspace"],
+            "enumDescriptions": [
+              "Show all tasks (auto-detected and workspace)",
+              "Show only auto-detected tasks (npm, gulp, etc.)",
+              "Show only workspace tasks (defined in tasks.json)"
+            ],
+            "description": "VSCode Tasks in Sidebar: filter tasks by their origin",
+            "scope": "resource"
           }
         }
       }

--- a/src/vscode-tasks-sidebar/settings.ts
+++ b/src/vscode-tasks-sidebar/settings.ts
@@ -21,3 +21,17 @@ export function getBlacklist(): string[] {
     .split(",")
     .filter(Boolean);
 }
+
+export enum TaskSourceFilter {
+  All = "all",
+  AutoDetected = "autoDetected",
+  Workspace = "workspace",
+}
+
+export const VSCODE_WORKSPACE_SOURCE = "Workspace";
+
+export function getTaskSourceFilter(): TaskSourceFilter {
+  return vscode.workspace
+    .getConfiguration()
+    .get<TaskSourceFilter>("vscodeTasksSidebar.taskSource", TaskSourceFilter.All);
+}

--- a/src/vscode-tasks-sidebar/vscodeTasksProvider.ts
+++ b/src/vscode-tasks-sidebar/vscodeTasksProvider.ts
@@ -1,5 +1,5 @@
 import * as vscode from "vscode";
-import { getBlacklist, getWhitelist, isResultGrouped } from "./settings";
+import { getBlacklist, getTaskSourceFilter, getWhitelist, isResultGrouped, TaskSourceFilter, VSCODE_WORKSPACE_SOURCE } from "./settings";
 import { VscodeGroup } from "./vscodeGroup";
 import { VscodeTask } from "./vscodeTask";
 
@@ -29,9 +29,18 @@ export class VscodeTasksProvider implements vscode.TreeDataProvider<
 
       const whitelist = getWhitelist();
       const blacklist = getBlacklist();
+      const taskSourceFilter = getTaskSourceFilter();
 
       const cacheTasks: VscodeTask[] = [];
       for (const task of tasks) {
+        // filter by task origin
+        if (taskSourceFilter === TaskSourceFilter.Workspace && task.source !== VSCODE_WORKSPACE_SOURCE) {
+          continue;
+        }
+        if (taskSourceFilter === TaskSourceFilter.AutoDetected && task.source === VSCODE_WORKSPACE_SOURCE) {
+          continue;
+        }
+
         // we allow only what is in whitelist or every task
         if (whitelist.length && !whitelist.includes(task.source)) {
           continue;


### PR DESCRIPTION
### Add `vscodeTasksSidebar.taskSource` setting to filter tasks by origin

**Problem**

The existing `includeSources` / `excludeSources` filters work at the granularity of individual task providers (npm, gulp, tsc…). But there's no simple way to say *"I only want my workspace tasks"* or *"I only want auto-detected tasks"* — you'd have to manually enumerate every provider you want to include or exclude, and maintain that list as your tooling evolves.

This is especially frustrating in large monorepos or polyglot projects where VS Code auto-detects dozens of tasks from multiple providers (npm, make, gradle…), burying the handful of hand-crafted tasks defined in `.vscode/tasks.json`. Conversely, some users rely exclusively on auto-detected tasks and don't want workspace-defined tasks cluttering the sidebar.

**Solution**

Add a new `vscodeTasksSidebar.taskSource` enum setting with three values:

| Value | Behaviour |
|---|---|
| `all` *(default)* | Show every task (current behaviour, no breaking change) |
| `autoDetected` | Show only tasks auto-detected by VS Code (npm, gulp, tsc…) |
| `workspace` | Show only tasks defined in `.vscode/tasks.json` |

The filter is applied **before** the existing whitelist/blacklist checks, so both mechanisms compose naturally.

**Implementation**

- New `TaskSourceFilter` type + `getTaskSourceFilter()` helper in `settings.ts`
- Source filtering in `vscodeTasksProvider.ts` using `task.source === 'Workspace'` to distinguish workspace tasks from auto-detected ones
- Enum setting registered in `package.json` with descriptive labels


<img width="647" height="266" alt="image" src="https://github.com/user-attachments/assets/679976c6-caa9-4d66-b2de-6a7af149c18e" />
