### PR TITLE
Add a settings shortcut button to the sidebar toolbar

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,6 +90,11 @@
         "command": "vscodeTasksSidebar.viewAsList",
         "title": "Show as list",
         "icon": "$(list-flat)"
+      },
+      {
+        "command": "vscodeTasksSidebar.openSettings",
+        "title": "Open extension settings",
+        "icon": "$(gear)"
       }
     ],
     "menus": {
@@ -108,6 +113,11 @@
           "command": "vscodeTasksSidebar.refresh",
           "when": "view == vscodeTasksSidebar",
           "group": "navigation@3"
+        },
+        {
+          "command": "vscodeTasksSidebar.openSettings",
+          "when": "view == vscodeTasksSidebar",
+          "group": "navigation@4"
         }
       ]
     },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -55,6 +55,15 @@ export function activate(context: vscode.ExtensionContext) {
     }),
   );
 
+  context.subscriptions.push(
+    vscode.commands.registerCommand("vscodeTasksSidebar.openSettings", () => {
+      vscode.commands.executeCommand(
+        "workbench.action.openSettings",
+        "@ext:iulian-radu-at.vscode-tasks-sidebar",
+      );
+    }),
+  );
+
   vscode.tasks.onDidStartTask((e) => {
     const vscodeTask = vscodeTasksProvider.findVscodeTask(e.execution.task);
     if (vscodeTask) {


### PR DESCRIPTION
### Add a settings shortcut button to the sidebar toolbar

**Problem**

The extension exposes several configuration options (`defaultGrouped`, `includeSources`, `excludeSources`, `taskSource`…), but there's no quick way to reach them from the sidebar itself. Users have to open the command palette or manually navigate through VS Code's settings UI and search for the right prefix. This adds unnecessary friction, especially for first-time users discovering the extension's filtering capabilities.

**Solution**

Add a gear icon (⚙) button to the sidebar view toolbar, next to the existing refresh button, that opens VS Code's settings UI pre-filtered to `vscodeTasksSidebar`. One click, straight to the right place.

**Implementation**

- Register a new `vscodeTasksSidebar.openSettings` command that calls `vscode.commands.executeCommand('workbench.action.openSettings', 'vscodeTasksSidebar')`
- Add the command to the `view/title` menu at `navigation` group position `@4` with the `gear` icon

<img width="355" height="182" alt="image" src="https://github.com/user-attachments/assets/9732d3ac-bec6-41fb-98f9-02a9530e11a2" />
 