### PR TITLE
Add Makefile task provider to detect and run Makefile targets from the sidebar

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,18 @@
     "Other"
   ],
   "contributes": {
+    "taskDefinitions": [
+      {
+        "type": "makefile",
+        "required": ["target"],
+        "properties": {
+          "target": {
+            "type": "string",
+            "description": "The Makefile target to run"
+          }
+        }
+      }
+    ],
     "viewsContainers": {
       "activitybar": [
         {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,4 +1,5 @@
 import * as vscode from "vscode";
+import { MakefileTaskProvider } from "./vscode-tasks-sidebar/makefileTaskProvider";
 import { isResultGrouped } from "./vscode-tasks-sidebar/settings";
 import { VscodeTasksProvider } from "./vscode-tasks-sidebar/vscodeTasksProvider";
 
@@ -9,6 +10,23 @@ export function activate(context: vscode.ExtensionContext) {
     "vscodeTasksSidebar",
     vscodeTasksProvider,
   );
+
+  // Register Makefile task provider
+  context.subscriptions.push(
+    vscode.tasks.registerTaskProvider(
+      MakefileTaskProvider.type,
+      new MakefileTaskProvider(),
+    ),
+  );
+
+  // Watch for Makefile changes to auto-refresh
+  const makefileWatcher = vscode.workspace.createFileSystemWatcher(
+    "**/Makefile",
+  );
+  makefileWatcher.onDidChange(() => vscodeTasksProvider.refresh());
+  makefileWatcher.onDidCreate(() => vscodeTasksProvider.refresh());
+  makefileWatcher.onDidDelete(() => vscodeTasksProvider.refresh());
+  context.subscriptions.push(makefileWatcher);
 
   // Listen for configuration changes
   context.subscriptions.push(

--- a/src/vscode-tasks-sidebar/makefileTaskProvider.ts
+++ b/src/vscode-tasks-sidebar/makefileTaskProvider.ts
@@ -1,0 +1,120 @@
+import * as vscode from "vscode";
+
+const MAKEFILE_TASK_TYPE = "makefile";
+
+const reTarget = /^([a-zA-Z0-9][a-zA-Z0-9_\-./]*)(?:\s*):/;
+const reSpecialTarget = /^\./;
+const reAssignment = /^[a-zA-Z_][a-zA-Z0-9_]*\s*(?:::|[:?+!])?=/;
+const reDirective =
+  /^\s*(?:ifeq|ifneq|ifdef|ifndef|else|endif|include|-include|sinclude|define|endef|export|unexport|override|vpath)\b/;
+
+interface MakefileTaskDefinition extends vscode.TaskDefinition {
+  target: string;
+}
+
+export class MakefileTaskProvider implements vscode.TaskProvider {
+  public static readonly type = MAKEFILE_TASK_TYPE;
+
+  async provideTasks(): Promise<vscode.Task[]> {
+    const tasks: vscode.Task[] = [];
+    const makefiles = await vscode.workspace.findFiles(
+      "**/Makefile",
+      "**/node_modules/**",
+    );
+
+    for (const makefileUri of makefiles) {
+      const targets = await this.parseMakefileTargets(makefileUri);
+      const folder = vscode.workspace.getWorkspaceFolder(makefileUri);
+      if (!folder) {
+        continue;
+      }
+
+      for (const target of targets) {
+        const task = this.createTask(target, folder, makefileUri);
+        tasks.push(task);
+      }
+    }
+
+    return tasks;
+  }
+
+  resolveTask(task: vscode.Task): vscode.Task | undefined {
+    const definition = task.definition as MakefileTaskDefinition;
+    if (!definition.target) {
+      return undefined;
+    }
+
+    const folder = task.scope as vscode.WorkspaceFolder;
+    return this.createTask(definition.target, folder);
+  }
+
+  private createTask(
+    target: string,
+    folder: vscode.WorkspaceFolder,
+    makefileUri?: vscode.Uri,
+  ): vscode.Task {
+    const definition: MakefileTaskDefinition = {
+      type: MAKEFILE_TASK_TYPE,
+      target,
+    };
+
+    const cwd = makefileUri
+      ? vscode.Uri.joinPath(makefileUri, "..").fsPath
+      : folder.uri.fsPath;
+
+    const execution = new vscode.ShellExecution(`make`, [target], { cwd });
+
+    const task = new vscode.Task(
+      definition,
+      folder,
+      target,
+      MAKEFILE_TASK_TYPE,
+      execution,
+    );
+
+    task.group = vscode.TaskGroup.Build;
+    task.detail = `make ${target}`;
+
+    return task;
+  }
+
+  private async parseMakefileTargets(
+    makefileUri: vscode.Uri,
+  ): Promise<string[]> {
+    const content = await vscode.workspace.fs.readFile(makefileUri);
+    const text = Buffer.from(content).toString("utf-8");
+    const lines = text.split("\n");
+
+    const targets: string[] = [];
+    for (const line of lines) {
+      if (line.startsWith("\t") || line.startsWith("#")) {
+        continue;
+      }
+
+      if (reAssignment.test(line)) {
+        continue;
+      }
+
+      if (reDirective.test(line)) {
+        continue;
+      }
+
+      const match = reTarget.exec(line);
+      if (!match) {
+        continue;
+      }
+
+      const target = match[1];
+
+      if (reSpecialTarget.test(target)) {
+        continue;
+      }
+
+      if (!targets.includes(target)) {
+        targets.push(target);
+      }
+    }
+
+    return targets;
+  }
+}


### PR DESCRIPTION
### Add Makefile task provider

Automatically detect Makefile targets and expose them as runnable tasks in the sidebar.

- New `MakefileTaskProvider` that parses `Makefile` files, extracts targets (filtering out variables, directives, special targets) and creates `make <target>` shell tasks
- Registered in `extension.ts` with a `FileSystemWatcher` on `**/Makefile` for auto-refresh
- Declared `makefile` task type in `package.json` `contributes.taskDefinitions